### PR TITLE
Fixed [issue #77]: diff now outputs to file instead of STDOUT; new op…

### DIFF
--- a/R/Rlib/include_diff.R
+++ b/R/Rlib/include_diff.R
@@ -2,21 +2,21 @@
 #
 # Author: Tim Sterne-Weiler, 2014
 # tim.sterne.weiler@utoronto.ca
+# Modifications by Ulrich Braunschweig 2018
 
 #  This function takes a qual and returns c(post_alpha, post_beta)
 #  Increments by prior alpha and prior distribution beta, uniform by default
 parseQual <- function(qual, prior_alpha=1, prior_beta=1) {
-    if(is.na(qual) || !grepl("@", qual)) { return(c(prior_alpha, prior_beta)) }  ## for INT NA Columns
-    res <- unlist(strsplit(unlist(strsplit(as.character(qual), "@"))[2], ","))
-    if(is.na(res[1]) || is.na(res[2])) { return(c(prior_alpha, prior_beta)) }
-    if(is.null(res[1]) || is.null(res[2])) { return(c(prior_alpha, prior_beta)) }
-    if(res[1] == "NA" || res[2] == "NA") { return(c(prior_alpha, prior_beta)) }
-    res <- as.numeric(res)
-    if(is.nan(res[1]) || is.nan(res[2])) { return(c(prior_alpha, prior_beta)) }
-    if(is.infinite(res[1]) || is.infinite(res[2])) { return(c(prior_alpha, prior_beta)) }
-    res[1] <- res[1] + prior_alpha
-    res[2] <- res[2] + prior_beta
-    res
+    res1 <- as.numeric(sub("[^@]*@([^,]*),.*", "\\1", qual))
+    res2 <- as.numeric(sub("[^@]*@[^,]*,(.*)", "\\1", qual))
+
+    irreg <- is.na(res1) | is.null(res1) | is.infinite(res1) |
+        is.na(res2) | is.null(res2) | is.infinite(res2)
+    res1[irreg] <- 0
+    res2[irreg] <- 0
+    res1 <- res1 + prior_alpha
+    res2 <- res2 + prior_beta
+    cbind(res1, res2)
 }
 
 # calculate the probability that the first dist is > than second
@@ -56,7 +56,7 @@ betaCI <- function(betaDist, percentile = c(0.05, 0.95)) {
     quantile(betaDist, p=percentile, na.rm = T)
 }
 
-# Extention of betaCI function that includes the sampling step
+# Extension of betaCI function that includes the sampling step
 betaCISample <- function(alpha, beta, n = 5000) {
     if (is.na(alpha) || is.na(beta)) {
       sample <- NA 
@@ -68,7 +68,7 @@ betaCISample <- function(alpha, beta, n = 5000) {
 
 
 ### MAKE VISUAL OUTPUT
-plotDiff <- function(inpOne, inpTwo, expOne, expTwo, maxD, medOne, medTwo, sampOneName, sampTwoName, rever ) {
+plotDiff <- function(inpOne, inpTwo, expOne, expTwo, maxD, medOne, medTwo, sampOneName, sampTwoName, rever) {
 
   if(rever) {   #write this better. ;-)
     curCol <- cbb[3:2]
@@ -112,7 +112,111 @@ plotPrint <- function(plotTitle, plotCoord, plotList) {
     popViewport(1)
 }
 
-# Shuffle...
-shuffle <- function(x) {
-    sample(x, length(x))	
+diffBeta <- function(i, lines, opt,
+                     shapeFirst, shapeSecond,
+                     totalFirst, totalSecond,
+                     shapeFirstAve, shapeSecondAve,
+                     expFirst, expSecond,
+                     repA.qualInd, repB.qualInd) {
+### Main diff functionality; fit beta distributions to sample groups for one event and compare
+### Is applied to each line of the current nLines of the INCLUSION... table
+
+    ## if no data, next; # adapted from @lpantano's fork  7/22/2015
+    if( (sum(totalFirst[i,] > (opt$minReads + opt$alpha + opt$beta)) < opt$minSamples) ||
+        (sum(totalSecond[i,] > (opt$minReads + opt$alpha + opt$beta)) < opt$minSamples) ) {
+              return(NULL)
+    }
+
+    ## Sample Posterior Distributions
+    psiFirst <- lapply(1:(dim(shapeFirst)[2]), function(x) {
+      #sample here from rbeta(N, alpha, beta) if > -e
+      if(totalFirst[i,x] < opt$minReads) { return(NULL) }
+      rbeta(opt$size, shape1=shapeFirst[i,x,1], shape2=shapeFirst[i,x,2])
+    })
+
+    psiSecond <- lapply(1:(dim(shapeSecond)[2]), function(x) {
+      #sample here from rbeta(N, alpha, beta) if > -e
+      if(totalSecond[i,x] < opt$minReads) { return(NULL) }
+      rbeta(opt$size, shape1=shapeSecond[i,x,1], shape2=shapeSecond[i,x,2])
+    })
+
+    if(opt$paired) { #make sure both samples have a non-NULL replicate
+      for(lstInd in 1:length(psiFirst)) {
+        if(is.null(psiFirst[[lstInd]]) || is.null(psiSecond[[lstInd]])) {
+          psiFirst[[lstInd]] <- NULL
+          psiSecond[[lstInd]] <- NULL
+        }
+      }
+    }
+
+    ## Create non-parametric Joint Distributions
+    psiFirstComb  <- do.call(c, psiFirst)
+    psiSecondComb <- do.call(c, psiSecond)
+
+    if( length(psiFirstComb) <= 0 || length(psiSecondComb) <= 0 ) { return(NULL) }
+
+    ## if they aren't paired, then shuffle the joint distributions...
+    if( !opt$paired ) {
+      paramFirst <- try (suppressWarnings(
+                              fitdistr(psiFirstComb,
+                                      "beta",
+                                      list( shape1=shapeFirstAve[i,1], shape2=shapeFirstAve[i,2])
+                              )$estimate ), TRUE )
+      paramSecond <- try (suppressWarnings(
+                              fitdistr(psiSecondComb,
+                                      "beta",
+                                      list( shape1=shapeSecondAve[i,1], shape2=shapeSecondAve[i,2])
+                              )$estimate ), TRUE )
+      ## if optimization fails its because the distribution is too narrow
+      ## in which case our starting shapes should already be good enough
+      if(class(paramFirst) != "try-error") {
+        psiFirstComb <- rbeta(opt$size, shape1=paramFirst[1], shape2=paramFirst[2])
+      }
+      if(class(paramSecond) != "try-error") {
+        psiSecondComb <- rbeta(opt$size, shape1=paramSecond[1], shape2=paramSecond[2])
+      }
+    }
+
+    ## get empirical posterior median of psi
+    medOne <- median(psiFirstComb)
+    medTwo <- median(psiSecondComb)
+
+    ## look for a max difference given prob cutoff...
+    if(medOne > medTwo) {
+      max <- maxDiff(psiFirstComb, psiSecondComb, opt$prob)
+    } else {
+      max <- maxDiff(psiSecondComb, psiFirstComb, opt$prob)
+    }
+
+    ## SIGNIFICANT from here on out:
+
+    filtOut <- sprintf("%s\t%s\t%f\t%f\t%f\t%s", lines[[i]][1], lines[[i]][2], medOne, medTwo, medOne - medTwo, round(max,2))
+
+    ## check for significant difference
+    if(max < opt$minDiff) {
+      ## non-sig, return null plots and text output
+      return(list(NULL, NULL, NULL, NULL, filtOut))
+    } else {
+      sigInd <- i
+
+      if (opt$noPDF) {
+        eventTitle <- NULL
+        eventCoord <- NULL
+        retPlot    <- NULL
+      } else {
+        eventTitle <- paste(c("Gene: ", lines[[i]][1], "  Event: ", lines[[i]][2]), collapse="")
+        eventCoord <- paste(c("Coordinates: ", lines[[i]][3]), collapse="")
+
+        ## Print visual output to pdf;
+        if( medOne > medTwo ) {
+            retPlot <- plotDiff(psiFirstComb, psiSecondComb,
+                                expFirst[i,], expSecond[i,], max, medOne, medTwo, sampOneName, sampTwoName, FALSE)
+        } else {
+            retPlot <- plotDiff(psiSecondComb, psiFirstComb,
+                                expFirst[i,], expSecond[i,], max, medTwo, medOne, sampTwoName, sampOneName, TRUE)
+        }
+        ## sig event return
+        return(list(retPlot, eventTitle, eventCoord, sigInd, filtOut))  #return of mclapply function
+      }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ VAST-TOOLS can be run as simply as:
 
 > vast-tools compare -a tissueA_rep1,tissueA_rep2 -b tissueB_rep1,tissueB_rep2
 OR
-> vast-tools diff -a tissueA_rep1,tissueA_rep2 -b tissueB_rep1,tissueB_rep2 > INCLUSION-FILTERED.tab
+> vast-tools diff -a tissueA_rep1,tissueA_rep2 -b tissueB_rep1,tissueB_rep2
 > vast-tools plot INCLUSION-FILTERED.tab
 ~~~~
 
@@ -201,7 +201,7 @@ by running it on a cluster.  The ``-c`` flag can be passed to both ``align`` and
 ~~~~ 
 AND
 ~~~~
-> vast-tools diff -a tissueA_rep1,tissueA_rep2 -b tissueB_rep1,tissueB_rep2 -c 8 > INCLUSION-FILTERED.tab
+> vast-tools diff -a tissueA_rep1,tissueA_rep2 -b tissueB_rep1,tissueB_rep2
 ~~~~
 
 
@@ -330,7 +330,7 @@ PSI/PSU/PIR.  With replicate data, joint posterior distributions for a sample ar
 empirical posterior distributions of the replicates using maximum-likelihood (MLE) fitting.
 
 ~~~~
-> vast-tools diff -a sampA_r1,sampA_r2,sampA_r3 -b sampB_r1,sampB_r2 -o outputdir > outputdir/diff_output.tab
+> vast-tools diff -a sampA_r1,sampA_r2,sampA_r3 -b sampB_r1,sampB_r2 -o outputdir -d outbase
 ~~~~
 Note: Sample names do not have to follow any specific convention as long as they remain valid ASCII words and any number of replicate sample names may be given 1:N.
 
@@ -380,7 +380,7 @@ is compared to PerturbationB.  No MLE fitting is used in this case.
 
 In all multireplicate cases where `--paired=FALSE`, the posterior distributions
 of the individual replicates are used to estimate a 'best fit joint posterior' distribution
-over psi for each sample.
+over PSI for each sample.
  
 *Performance Options*
 
@@ -417,8 +417,8 @@ The text output of diff looks like:
 
 Where for example the first event HsaEX0008312 in the BOD1L gene has multireplicate point estimate
 for SampleA of 0.12 and 0.7 for SampleB.  While this gives an expected value for the difference of
-Psi (deltaPsi) between SampleA and SampleB of -0.57, the minimum value (`MV`) for |dPsi| at 0.95 is
-0.3, meaning that there is a 0.95 probability that |deltaPsi| is greater than 0.3. Use this value 
+PSI (dPsi/ΔPSI) between SampleA and SampleB of -0.57, the minimum value (`MV`) for |ΔPSI| at 0.95 is
+0.3, meaning that there is a 0.95 probability that |ΔPSI| is greater than 0.3. Use this value 
 to filter for events that are statistically likely to have at least a minimal difference of some 
 magnitude that you deem to be biologically relevant.  The `-m` argument (default 0.1) provides a
 lower bound for events that will be plotted to PDF and printed to file based on `MV`.  As a cutoff,
@@ -428,10 +428,10 @@ would rather view more events that may have significant but modest changes.
 
 ![Diff](https://raw.githubusercontent.com/vastgroup/vast-tools/master/R/sample_data/DiffExample.png "Example") 
 
-The output plot above shows in the left panel the two joint posterior distributions over psi, and the
-point estimates for each replicate plotted as points below the histograms.  In the right panel:
-the y-axis represents the probability of delta psi being greater than some magnitude value of x (shown on the x-axis).
-The red line indicates the maximal value of x where P(deltaPsi > x) > `-r`, or the 0.95 default.  
+The output plot above shows in the left panel the two joint posterior distributions over PSI, and the
+point estimates for each replicate plotted as points below the histograms.  In the right panel,
+the y-axis represents the probability of deltaPsi being greater than some magnitude value of x (shown on the x-axis).
+The red line indicates the maximal value of x where P(ΔPSI > x) > `-r`, or the 0.95 default.  
 
 ### Plotting
 


### PR DESCRIPTION
This is a major overhaul for **diff**:
- Greater than 10x performance boost. E.g., an mm9 comparison with two samples each now runs in 30 min on 2 cores.
- Output table written to file rather than to STDOUT, in agreement with other modules
- PDF output is optional
- Default nLines lowered to 5000 with almost no performance hit but decreased memory
- Adaptations to README to reflect these changes