### PR TITLE
fix refactoring typo that prevents correct estimates in diff module

### DIFF
--- a/R/vastdiff.R
+++ b/R/vastdiff.R
@@ -236,7 +236,7 @@ while(length( lines <- readLines(inputFile, n=opt$nLines) ) > 0) {
     plotListed <- mclapply(1:length(lines), diffBeta, lines=lines, opt=opt,
                            shapeFirst, shapeSecond,
                            totalFirst, totalSecond,
-                           firstShapeAve, secondShapeAve,
+                           shapeFirstAve, shapeSecondAve,
                            expFirst, expSecond,
                            repA.qualInd=repA.qualInd, repB.qualInd=repB.qualInd,
                            mc.cores=opt$cores, mc.preschedule=TRUE, mc.cleanup=TRUE) #End For


### PR DESCRIPTION
- this refactoring typo prevents the fitting of a new posterior beta distribution using maximum-likelihood estimation with fitdistr in function diffBeta as no valid initial values are given 
- the calculation now takes about 10 times longer