### PR TITLE
diff update

### DIFF
--- a/R/Rlib/include_diff.R
+++ b/R/Rlib/include_diff.R
@@ -1,11 +1,23 @@
 #!/usr/bin/env Rscript
 #
-# Author: Tim Sterne-Weiler, 2014
-# tim.sterne.weiler@utoronto.ca
-# Modifications by Ulrich Braunschweig 2018
+# Author: Tim Sterne-Weiler, Ulrich Braunschweig 2014-2023
+# u.braunschweig@utoronto.ca
 
-#  This function takes a qual and returns c(post_alpha, post_beta)
-#  Increments by prior alpha and prior distribution beta, uniform by default
+## Check that columns of INCLUSION... table are what we think they are
+checkHeader <- function(x, replicateA, replicateB) {
+    reps <- c(replicateA, replicateB)
+    sampInd <- unlist(sapply(reps, FUN=function(y) {which(x == y)}))
+    if (length(sampInd) != length(reps)) {
+        stop("[vast diff error]: Not all sampleNames found in input header!")
+    }
+    namesOK <- all(paste0(reps, "-Q") == x[sampInd + 1])
+    if (!namesOK |  !all(x[1:3] == c("GENE", "EVENT", "COORD"))) {
+        stop("[vast diff error]: Input table does not have expected format!")
+    }
+}
+
+##  This function takes a qual and returns c(post_alpha, post_beta)
+##  Increments by prior alpha and prior distribution beta, uniform by default
 parseQual <- function(qual, prior_alpha=1, prior_beta=1) {
     res1 <- as.numeric(sub("[^@]*@([^,]*),.*", "\\1", qual))
     res2 <- as.numeric(sub("[^@]*@[^,]*,(.*)", "\\1", qual))
@@ -19,11 +31,11 @@ parseQual <- function(qual, prior_alpha=1, prior_beta=1) {
     cbind(res1, res2)
 }
 
-# calculate the probability that the first dist is > than second
-#  P(psi1 > psi2) when alpha=0; more generally we are determining the probability
-#  that Psi1 is greater than Psi2 by alpha.. eg. P((psi1 - psi2) > alpha) = 
+## Calculate the probability that the first dist is > than second
+##  P(psi1 > psi2) when alpha=0; more generally we are determining the probability
+##  that Psi1 is greater than Psi2 by alpha.. eg. P((psi1 - psi2) > alpha) = 
 ## IMPORTANT: run this function as sample(firstDist, length(firstDist)) AND
-##								           sample(secondDist, length(secondDist))
+##	      sample(secondDist, length(secondDist))
 ## UNLESS you have paired data, then don't sample.
 pDiff  <- function(firstDist, secondDist, alpha=0.15) {
     N <- length(firstDist)	
@@ -31,10 +43,10 @@ pDiff  <- function(firstDist, secondDist, alpha=0.15) {
     pass / N
 }
 
-#  This function finds the maximum difference between psi1 and psi2 given
-#  at least some acceptable probability for difference.  Defaults to 0.8
-#  distributions where no diff value exists with a probability > 0.8 are given
-#  maxDiff of 0.
+##  This function finds the maximum difference between psi1 and psi2 given
+##  at least some acceptable probability for difference.  Defaults to 0.8
+##  distributions where no diff value exists with a probability > 0.8 are given
+##  maxDiff of 0.
 maxDiff <- function(firstDist, secondDist, acceptProb=0.9) {
     alphaSet <- seq(0,1,0.01)  #make this global?
     probs <- unlist(lapply(alphaSet, function(x) { pDiff(firstDist, secondDist, x) }))
@@ -42,8 +54,7 @@ maxDiff <- function(firstDist, secondDist, acceptProb=0.9) {
     alphaSet[ind]
 }
 
-#
-#  return the beta variance
+##  Return the beta variance
 betaVar <- function(alpha, beta) {
     var <- alpha*beta / (
 	 ((alpha + beta) ** 2) * (alpha + beta + 1)
@@ -51,12 +62,12 @@ betaVar <- function(alpha, beta) {
     var
 }
 
-# 
+## Return a confidence interval 
 betaCI <- function(betaDist, percentile = c(0.05, 0.95)) {
     quantile(betaDist, p=percentile, na.rm = T)
 }
 
-# Extension of betaCI function that includes the sampling step
+## Extension of betaCI function that includes the sampling step
 betaCISample <- function(alpha, beta, n = 5000) {
     if (is.na(alpha) || is.na(beta)) {
       sample <- NA 
@@ -67,7 +78,7 @@ betaCISample <- function(alpha, beta, n = 5000) {
 }
 
 
-### MAKE VISUAL OUTPUT
+## MAKE VISUAL OUTPUT
 plotDiff <- function(inpOne, inpTwo, expOne, expTwo, maxD, medOne, medTwo, sampOneName, sampTwoName, rever) {
 
   if(rever) {   #write this better. ;-)
@@ -118,45 +129,43 @@ diffBeta <- function(i, lines, opt,
                      shapeFirstAve, shapeSecondAve,
                      expFirst, expSecond,
                      repA.qualInd, repB.qualInd) {
-### Main diff functionality; fit beta distributions to sample groups for one event and compare
-### Is applied to each line of the current nLines of the INCLUSION... table
+## Main diff functionality; fit beta distributions to sample groups for one event and compare
+## Is applied to each line of the current nLines of the INCLUSION... table
 
     ## if no data, next; # adapted from @lpantano's fork  7/22/2015
-    if( (sum(totalFirst[i,] > (opt$minReads + opt$alpha + opt$beta)) < opt$minSamples) ||
+    if ((sum(totalFirst[i,] > (opt$minReads + opt$alpha + opt$beta)) < opt$minSamples) ||
         (sum(totalSecond[i,] > (opt$minReads + opt$alpha + opt$beta)) < opt$minSamples) ) {
               return(NULL)
     }
 
     ## Sample Posterior Distributions
     psiFirst <- lapply(1:(dim(shapeFirst)[2]), function(x) {
-      #sample here from rbeta(N, alpha, beta) if > -e
-      if(totalFirst[i,x] < opt$minReads) { return(NULL) }
+      ## sample here from rbeta(N, alpha, beta) if > -e
+      if (totalFirst[i,x] < opt$minReads) { return(NULL) }
       rbeta(opt$size, shape1=shapeFirst[i,x,1], shape2=shapeFirst[i,x,2])
     })
 
     psiSecond <- lapply(1:(dim(shapeSecond)[2]), function(x) {
-      #sample here from rbeta(N, alpha, beta) if > -e
-      if(totalSecond[i,x] < opt$minReads) { return(NULL) }
+      ## sample here from rbeta(N, alpha, beta) if > -e
+      if (totalSecond[i,x] < opt$minReads) { return(NULL) }
       rbeta(opt$size, shape1=shapeSecond[i,x,1], shape2=shapeSecond[i,x,2])
     })
 
-    if(opt$paired) { #make sure both samples have a non-NULL replicate
-      for(lstInd in 1:length(psiFirst)) {
-        if(is.null(psiFirst[[lstInd]]) || is.null(psiSecond[[lstInd]])) {
-          psiFirst[[lstInd]] <- NULL
-          psiSecond[[lstInd]] <- NULL
-        }
-      }
+    if (opt$paired) { 
+        ## make sure both samples have a non-NULL replicate
+        pairedNull <- sapply(psiFirst, is.null) & sapply(psiSecond, is.null)
+        psiFirst[pairedNull] <- NULL
+        psiSecond[pairedNull] <- NULL
     }
 
     ## Create non-parametric Joint Distributions
     psiFirstComb  <- do.call(c, psiFirst)
     psiSecondComb <- do.call(c, psiSecond)
 
-    if( length(psiFirstComb) <= 0 || length(psiSecondComb) <= 0 ) { return(NULL) }
+    if (length(psiFirstComb) <= 0 || length(psiSecondComb) <= 0 ) { return(NULL) }
 
     ## if they aren't paired, then shuffle the joint distributions...
-    if( !opt$paired ) {
+    if (!opt$paired ) {
       paramFirst <- try (suppressWarnings(
                               fitdistr(psiFirstComb,
                                       "beta",
@@ -169,10 +178,10 @@ diffBeta <- function(i, lines, opt,
                               )$estimate ), TRUE )
       ## if optimization fails its because the distribution is too narrow
       ## in which case our starting shapes should already be good enough
-      if(class(paramFirst) != "try-error") {
+      if (class(paramFirst) != "try-error") {
         psiFirstComb <- rbeta(opt$size, shape1=paramFirst[1], shape2=paramFirst[2])
       }
-      if(class(paramSecond) != "try-error") {
+      if (class(paramSecond) != "try-error") {
         psiSecondComb <- rbeta(opt$size, shape1=paramSecond[1], shape2=paramSecond[2])
       }
     }
@@ -182,21 +191,20 @@ diffBeta <- function(i, lines, opt,
     medTwo <- median(psiSecondComb)
 
     ## look for a max difference given prob cutoff...
-    if(medOne > medTwo) {
+    if (medOne > medTwo) {
       max <- maxDiff(psiFirstComb, psiSecondComb, opt$prob)
     } else {
       max <- maxDiff(psiSecondComb, psiFirstComb, opt$prob)
     }
 
-    ## SIGNIFICANT from here on out:
-
     filtOut <- sprintf("%s\t%s\t%f\t%f\t%f\t%s", lines[[i]][1], lines[[i]][2], medOne, medTwo, medOne - medTwo, round(max,2))
 
     ## check for significant difference
-    if(max < opt$minDiff) {
+    if (max < opt$minDiff) {
       ## non-sig, return null plots and text output
       return(list(NULL, NULL, NULL, NULL, filtOut))
-    } else {
+    } else { 
+      ## SIGNIFICANT from here on out
       sigInd <- i
 
       if (opt$noPDF) {
@@ -208,7 +216,7 @@ diffBeta <- function(i, lines, opt,
         eventCoord <- paste(c("Coordinates: ", lines[[i]][3]), collapse="")
 
         ## Print visual output to pdf;
-        if( medOne > medTwo ) {
+        if (medOne > medTwo) {
             retPlot <- plotDiff(psiFirstComb, psiSecondComb,
                                 expFirst[i,], expSecond[i,], max, medOne, medTwo, sampOneName, sampTwoName, FALSE)
         } else {

--- a/R/Rlib/include_diff.R
+++ b/R/Rlib/include_diff.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 #
-# Author: Tim Sterne-Weiler, Ulrich Braunschweig 2014-2023
+# Author: Tim Sterne-Weiler, Ulrich Braunschweig 2014-2024
 # u.braunschweig@utoronto.ca
 
 ## Check that columns of INCLUSION... table are what we think they are
@@ -8,7 +8,7 @@ checkHeader <- function(x, replicateA, replicateB) {
     reps <- c(replicateA, replicateB)
     sampInd <- unlist(sapply(reps, FUN=function(y) {which(x == y)}))
     if (length(sampInd) != length(reps)) {
-        stop("[vast diff error]: Not all sampleNames found in input header!\n")
+        stop("[vast diff error]: Not all replicate names found in input header!\n")
     }
     namesOK <- all(paste0(reps, "-Q") == x[sampInd + 1])
     if (!namesOK |  !all(x[1:3] == c("GENE", "EVENT", "COORD"))) {
@@ -32,14 +32,14 @@ parseQual <- function(qual, prior_alpha=1, prior_beta=1) {
 }
 
 ## Calculate the probability that the first dist is > than second
-##  P(psi1 > psi2) when alpha=0; more generally we are determining the probability
-##  that Psi1 is greater than Psi2 by alpha.. eg. P((psi1 - psi2) > alpha) = 
+## P(psi1 > psi2) when alpha=0; more generally we are determining the probability
+## that psi1 is greater than psi2 by alpha.. eg. P((psi1 - psi2) > alpha) = 
 ## IMPORTANT: run this function as sample(firstDist, length(firstDist)) AND
 ##	      sample(secondDist, length(secondDist))
 ## UNLESS you have paired data, then don't sample.
 pDiff  <- function(firstDist, secondDist, alpha=0.15) {
-    N <- length(firstDist)	
-    pass <- length( which( (firstDist - secondDist) > alpha  ) )
+    N <- length(firstDist)
+    pass <- length(which((firstDist - secondDist) > alpha))
     pass / N
 }
 
@@ -47,9 +47,9 @@ pDiff  <- function(firstDist, secondDist, alpha=0.15) {
 ##  at least some acceptable probability for difference.  Defaults to 0.8
 ##  distributions where no diff value exists with a probability > 0.8 are given
 ##  maxDiff of 0.
-maxDiff <- function(firstDist, secondDist, acceptProb=0.9) {
-    alphaSet <- seq(0,1,0.01)  #make this global?
-    probs <- unlist(lapply(alphaSet, function(x) { pDiff(firstDist, secondDist, x) }))
+maxDiff <- function(firstDist, secondDist, acceptProb=0.9, alphaSet) {
+    probs <- unlist(lapply(alphaSet, pDiff, 
+        firstDist=firstDist, secondDist=secondDist))
     ind <- max(c(which(probs > acceptProb), 1))
     alphaSet[ind]
 }
@@ -77,9 +77,9 @@ betaCISample <- function(alpha, beta, n = 5000) {
     return(betaCI(sample))
 }
 
-
-## MAKE VISUAL OUTPUT
-plotDiff <- function(inpOne, inpTwo, expOne, expTwo, maxD, medOne, medTwo, sampOneName, sampTwoName, rever) {
+plotDiff <- function(inpOne, inpTwo, expOne, expTwo, maxD, medOne, medTwo, 
+    sampOneName, sampTwoName, alphaSet, rever) {
+### Make visual output
 
   if(rever) {   #write this better. ;-)
     curCol <- cbb[3:2]
@@ -87,33 +87,34 @@ plotDiff <- function(inpOne, inpTwo, expOne, expTwo, maxD, medOne, medTwo, sampO
     curCol <- cbb[2:3]
   }
 
-  if(length(expOne) == 0 || length(expTwo) == 0) { return(NULL) }
+  if (length(expOne) == 0 || length(expTwo) == 0) {return(NULL)}
   one <- data.frame(x=expOne, y=-0.5)
   two <- data.frame(x=expTwo, y=-0.5)
 
-  distPlot <- ggplot(melt(as.data.frame(
-         do.call(cbind, list(inpOne, inpTwo))
-         ), measure.vars=c("V1","V2")), aes(fill=variable, x=value)) +
-         geom_histogram(aes(y=after_stat(density)), binwidth=0.03333, alpha=0.5, col="grey", position="identity") +
-         theme_bw() + scale_x_continuous(limits = c(0, 1), oob = scales::oob_keep) + xlab(expression(hat(Psi))) +
-         scale_fill_manual(values=curCol, labels=c(sampOneName, sampTwoName), name="Samples") +
-         geom_point(data=one, mapping=aes(x=x, y=y), col=cbb[2], fill=cbb[2], alpha=0.85, inherit.aes = FALSE) +
-         geom_point(data=two, mapping=aes(x=x, y=y), col=cbb[3], fill=cbb[3], alpha=0.85, inherit.aes = FALSE)
+  distPlot <- ggplot(melt(as.data.frame(do.call(cbind, list(inpOne, inpTwo))),
+                  measure.vars=c("V1","V2")), 
+      aes(fill=variable, x=value)) +
+      geom_histogram(aes(y=after_stat(density)), binwidth=0.03333, alpha=0.5, col="grey", position="identity") +
+      theme_bw() + scale_x_continuous(limits = c(0, 1), oob = scales::oob_keep) + xlab(expression(hat(Psi))) +
+      scale_fill_manual(values=curCol, labels=c(sampOneName, sampTwoName), name="Samples") +
+      geom_point(data=one, mapping=aes(x=x, y=y), col=cbb[2], fill=cbb[2], alpha=0.50, inherit.aes = FALSE) +
+      geom_point(data=two, mapping=aes(x=x, y=y), col=cbb[3], fill=cbb[3], alpha=0.50, inherit.aes = FALSE)
 
   probPlot <- ggplot(as.data.frame(cbind(seq(0,1,0.01),
-            unlist(lapply(alphaList, function(x) {
+            unlist(lapply(alphaSet, function(x) {
                pDiff(inpOne, inpTwo, x)
             })))), aes(x=V1, y=V2)) +
             geom_line() + theme_bw() +
             geom_vline(xintercept=maxD, lty="dashed", col=cbb[7]) +
             ylab(expression(P((hat(Psi)[1] - hat(Psi)[2]) > x))) +
-            xlab(expression(x)) + ylim(c(0,1)) +
+            xlab(expression(x)) + scale_y_continuous(limits = c(0, 1), oob = scales::oob_keep) +
             annotate("text", x=(maxD + 0.08), y=0.05, label=maxD, col=cbb[7])
 
-  return(list(distPlot, probPlot))
+  return(list(distPlot, probPlot))#
 }
 
 plotPrint <- function(plotTitle, plotCoord, plotList) {
+### Print saved plotting information to output file
     grid.newpage()
     pushViewport(viewport(layout = grid.layout(3, 2, widths = unit(c(5, 4), "null"), heights = unit(c(1, 0.5, 5), "null"))))
     grid.text(as.character(plotTitle), check.overlap=TRUE, gp=gpar(font=2), draw=T, vp = viewport(layout.pos.row = 1, layout.pos.col = 1:2))
@@ -128,26 +129,28 @@ diffBeta <- function(i, lines, opt,
                      totalFirst, totalSecond,
                      shapeFirstAve, shapeSecondAve,
                      expFirst, expSecond,
-                     repA.qualInd, repB.qualInd) {
+                     repA.qualInd, repB.qualInd,
+                     badFirst, badSecond,
+                     alphaSet) {
 ## Main diff functionality; fit beta distributions to sample groups for one event and compare
 ## Is applied to each line of the current nLines of the INCLUSION... table
 
     ## Sample Posterior Distributions
     psiFirst <- lapply(1:(dim(shapeFirst)[2]), function(x) {
       ## sample here from rbeta(N, alpha, beta) if > -e
-      if (totalFirst[i,x] < opt$minReads) { return(NULL) }
+      if (badFirst[i,x]) {return(NULL)}
       rbeta(opt$size, shape1=shapeFirst[i,x,1], shape2=shapeFirst[i,x,2])
     })
 
     psiSecond <- lapply(1:(dim(shapeSecond)[2]), function(x) {
       ## sample here from rbeta(N, alpha, beta) if > -e
-      if (totalSecond[i,x] < opt$minReads) { return(NULL) }
+      if (badSecond[i,x]) {return(NULL)}
       rbeta(opt$size, shape1=shapeSecond[i,x,1], shape2=shapeSecond[i,x,2])
     })
 
     if (opt$paired) { 
         ## Set matched samples to null in both if absent in one type
-        pairedNull <- sapply(psiFirst, is.null) & sapply(psiSecond, is.null)
+        pairedNull <- badFirst[i,] | badSecond[i,]
         psiFirst[pairedNull] <- NULL
         psiSecond[pairedNull] <- NULL
     }
@@ -156,27 +159,33 @@ diffBeta <- function(i, lines, opt,
     psiFirstComb  <- do.call(c, psiFirst)
     psiSecondComb <- do.call(c, psiSecond)
 
-    if (length(psiFirstComb) <= 0 || length(psiSecondComb) <= 0 ) { return(NULL) }
+    if (length(psiFirstComb) <= 0 || length(psiSecondComb) <= 0 ) {return(NULL)}
 
-    ## if they aren't paired, then shuffle the joint distributions...
+    ## Try to to fit a beta distribution on the replicates' parameter estimates.
     if (!opt$paired ) {
-      paramFirst <- try (suppressWarnings(
+      paramFirst <- try(suppressWarnings(
                               fitdistr(psiFirstComb,
                                       "beta",
-                                      list( shape1=shapeFirstAve[i,1], shape2=shapeFirstAve[i,2])
+                                      list(shape1=shapeFirstAve[i,1], shape2=shapeFirstAve[i,2])
                               )$estimate ), TRUE )
-      paramSecond <- try (suppressWarnings(
+      paramSecond <- try(suppressWarnings(
                               fitdistr(psiSecondComb,
                                       "beta",
-                                      list( shape1=shapeSecondAve[i,1], shape2=shapeSecondAve[i,2])
+                                      list(shape1=shapeSecondAve[i,1], shape2=shapeSecondAve[i,2])
                               )$estimate ), TRUE )
-      ## if optimization fails its because the distribution is too narrow
-      ## in which case our starting shapes should already be good enough
-      if (class(paramFirst) != "try-error") {
-        psiFirstComb <- rbeta(opt$size, shape1=paramFirst[1], shape2=paramFirst[2])
+      ## If optimization fails it's because the distribution is too narrow
+      ## in which case our starting shapes should already be good enough.
+      ## Shuffle since not paired, and downsample to size of smaller number
+      minSample <- min(length(psiFirstComb), length(psiSecondComb))
+      if (!inherits(paramFirst, "try-error")) {
+          psiFirstComb <- rbeta(opt$size, shape1=paramFirst[1], shape2=paramFirst[2])
+      } else {
+          psiFirstComb <- sample(psiFirstComb, minSample)
       }
-      if (class(paramSecond) != "try-error") {
-        psiSecondComb <- rbeta(opt$size, shape1=paramSecond[1], shape2=paramSecond[2])
+      if (!inherits(paramSecond, "try-error")) {
+          psiSecondComb <- rbeta(opt$size, shape1=paramSecond[1], shape2=paramSecond[2])
+      } else {
+          psiSecondComb <- sample(psiSecondComb, minSample)
       }
     }
 
@@ -186,9 +195,9 @@ diffBeta <- function(i, lines, opt,
 
     ## look for a max difference given prob cutoff...
     if (medOne > medTwo) {
-      max <- maxDiff(psiFirstComb, psiSecondComb, opt$prob)
+      max <- maxDiff(psiFirstComb, psiSecondComb, opt$prob, alphaSet)
     } else {
-      max <- maxDiff(psiSecondComb, psiFirstComb, opt$prob)
+      max <- maxDiff(psiSecondComb, psiFirstComb, opt$prob, alphaSet)
     }
 
     filtOut <- sprintf("%s\t%s\t%f\t%f\t%f\t%s", lines[[i]][1], lines[[i]][2], medOne, medTwo, medOne - medTwo, round(max,2))
@@ -198,27 +207,88 @@ diffBeta <- function(i, lines, opt,
       ## non-sig, return null plots and text output
       return(list(NULL, NULL, NULL, NULL, filtOut))
     } else { 
-      ## SIGNIFICANT from here on out
+      ## significant; plot
       sigInd <- i
+      eventTitle <- paste(c("Gene: ", lines[[i]][1], "  Event: ", lines[[i]][2]), collapse="")
+      eventCoord <- paste(c("Coordinates: ", lines[[i]][3]), collapse="")
 
-      if (opt$noPDF) {
-        eventTitle <- NULL
-        eventCoord <- NULL
-        retPlot    <- NULL
+      ## Store visual output to be printed to pdf
+      if (medOne > medTwo) {
+          retPlot <- plotDiff(psiFirstComb, psiSecondComb,
+                              expFirst[i,][!badFirst[i,]], expSecond[i,][!badSecond[i,]], 
+                              max, medOne, medTwo, sampOneName, sampTwoName, alphaSet, FALSE)
       } else {
-        eventTitle <- paste(c("Gene: ", lines[[i]][1], "  Event: ", lines[[i]][2]), collapse="")
-        eventCoord <- paste(c("Coordinates: ", lines[[i]][3]), collapse="")
-
-        ## Print visual output to pdf;
-        if (medOne > medTwo) {
-            retPlot <- plotDiff(psiFirstComb, psiSecondComb,
-                                expFirst[i,], expSecond[i,], max, medOne, medTwo, sampOneName, sampTwoName, FALSE)
-        } else {
-            retPlot <- plotDiff(psiSecondComb, psiFirstComb,
-                                expFirst[i,], expSecond[i,], max, medTwo, medOne, sampTwoName, sampOneName, TRUE)
-        }
+          retPlot <- plotDiff(psiSecondComb, psiFirstComb,
+                              expFirst[i,][!badFirst[i,]], expSecond[i,][!badSecond[i,]],
+                              max, medTwo, medOne, sampTwoName, sampOneName, alphaSet, TRUE)
       }
+      
       ## sig event return
-      return(list(retPlot, eventTitle, eventCoord, sigInd, filtOut))  #return of mclapply function
+      return(list(retPlot, eventTitle, eventCoord, sigInd, filtOut))
+    }
+}
+
+dummyBeta <- function(i, lines) {
+### Pruduce dummy text output for lines that fail -e and/or -S criteria
+
+    dummyOut <- sprintf("%s\t%s\t%f\t%f\t%f\t%s", 
+                        lines[[i]][1],
+                        lines[[i]][2],
+                        NA, NA, NA, NA)
+    return(list(NULL, NULL, NULL, NULL, dummyOut))
+
+}
+
+writeLog <- function(vastPath, opt) {
+### Add a line with call information to the general vast-tools log file
+
+    logName <- file.path(opt$output, "VTS_LOG_commands.txt")
+    vastVer <- scan(file.path(vastPath, "VERSION"), what="character", quiet = T)
+
+    ## Get date, time and vast-tools version
+    systime <- Sys.time()
+    sdate <- paste(
+	      sub("([0-9]{4})-.+", "\\1", systime),
+	      sub("[0-9]{4}-[0-9]{2}-([0-9]{2}).+", "\\1", systime),
+	      sub("[0-9]{4}-([0-9]{2})-.+", "\\1", systime),
+	      sep="-")
+    stime <- sub("[^ ]+ (.{5}):[0-9]{2}.*", "\\1", systime)
+
+    msg1 <- paste0(
+      "[VAST-TOOLS v", vastVer, ", ",
+      sdate, " (", stime, ")]"
+    )
+
+    msg2 <- "vast-tools diff"
+
+    ## Format input options
+    msg3 <- paste0(
+        "-a ", opt$replicateA, " ",
+        "-b ", opt$replicateB, " ",
+        "--sampleNameA ", opt$sampleNameA, " ",
+        "--sampleNameB ", opt$sampleNameB, " ",
+        "-i ", opt$input, " ",
+        "-n ", opt$nLines, " ",
+        "-p ", opt$paired, " ",
+        "-d ", opt$baseName, " ",
+        "-o ", opt$output, " ",
+        "-r ", opt$prob, " ",
+        "-m ", opt$minDiff, " ",
+        "-e ", opt$minReads, " ",
+        "-S ", opt$minSamples, " ",
+        "--alpha ", opt$alpha, " ",
+        "--beta ", opt$beta, " ",
+        "-s ", opt$size, " ",
+        "-z ", opt$seed
+    )
+
+    msg <- paste(msg1, msg2, msg3, paste = " ")
+
+    try_error <- try(logFile <- file(logName, "a"), silent = TRUE)
+    if (inherits(try_error, "try-error")) {
+        cat("[vast diff warning]: Could not open log file\n")
+    } else {
+        write(msg, logFile)
+        close(logFile)
     }
 }

--- a/R/vastdiff.R
+++ b/R/vastdiff.R
@@ -49,9 +49,6 @@ option.list <- list(
         help = "Name of the replicate set B, [default is first element of --replicateB]"),
     make_option(c("-i", "--input"), type = "character", default = "INCLUSION_LEVELS",
         help = "Exact or Partial match to PSI table in output directory [default %default]"),
-    make_option(c("-n", "--nLines"), type = "integer", default = "5000",
-        help = "Number of lines to read/process in parallel at a time... 
-                lower number = less memory = greater overhead [default %default]"),
     make_option(c("-p", "--paired"), action="store_true", default = FALSE,
         help = "Samples are paired, -a pairOneA,pairTwoA,.. -b pairOneB,pairTwoB,.. [default %default]\n
 
@@ -83,6 +80,9 @@ option.list <- list(
 [general options]"),
     make_option(c("-c", "--cores"), type = "integer", default = 1, metavar="int",
         help="Number of cores to use for plot processing.. [default %default]"),
+    make_option(c("-n", "--nLines"), type = "integer", default = "5000",
+        help = "Number of lines to read/process in parallel at a time... 
+                lower number = less memory = greater overhead [default %default]"),
     make_option(c("-z", "--seed"), type = "integer", default = 10, metavar="int",
         help="Seed the RNG for a deterministic result.. [default %default]"),
     make_option(c("-v", "--verbose"), type = "logical", default = TRUE, metavar=NULL,

--- a/R/vastdiff.R
+++ b/R/vastdiff.R
@@ -1,10 +1,9 @@
 #!/usr/bin/env Rscript
 
-# Author: Tim Sterne-Weiler, 2014
-# tim.sterne.weiler@utoronto.ca
-# Modifications Ulrich Braunschweig 2018-2019
+# Author: Tim Sterne-Weiler, Ulrich Braunschweig 2014-2023
+# u.braunschweig@utoronto.ca
 
-# Copyright (C) 2014 Tim Sterne-Weiler
+# Copyright (C) 2014 Tim Sterne-Weiler, Ulrich Braunschweig
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the "Software"), 
@@ -111,7 +110,7 @@ if (opt$minDiff < 0 | opt$minDiff >= 1) {
 }	
 
 
-loadPackages(c("MASS", "RColorBrewer", "reshape2", "ggplot2", "grid", "parallel"), local.lib=paste(c(scriptPath,"/Rlib"), collapse=""))
+loadPackages(c("MASS", "reshape2", "ggplot2", "grid", "parallel"), local.lib=paste(c(scriptPath,"/Rlib"), collapse=""))
 
 ## move to output directory
 setwd(opt$output)
@@ -145,47 +144,41 @@ if( length(firstRepSet) <= 0 ||
   stop("[vast diff error]: No replicate sample names given! -a sampA,sampB -b sampC,sampD")
 }
 
-# Set number of replicates
+## Set number of replicates
 firstRepN <- length(firstRepSet)
 secondRepN <- length(secondRepSet)
 
-# Make sure there are sample names
+## Make sure there are sample names
 if(is.null( opt$sampleNameA ) ) {
   opt$sampleNameA <- firstRepSet[1]
 }
 if(is.null( opt$sampleNameB ) ) {
   opt$sampleNameB <- secondRepSet[1]
 }
-# Set output sample names for plot
+## Set output sample names for plot
 sampOneName <- substr(opt$sampleNameA, 1, 9)
 sampTwoName <- substr(opt$sampleNameB, 1, 9)
 
 
-# Get header
+## Get header
 head_n <- unlist(strsplit(readLines( inputFile, n=1 ), "\t"))
 
-# check if header is correct..  TODO
+## Check if header is correct
+checkHeader(head_n, firstRepSet, secondRepSet)
+if (opt$verbose) {cat("[vast diff]: Input table format OK.")}
 
-# Indexes of samples of interest
+## Indexes of samples of interest
 repAind <- which( head_n %in% firstRepSet  )
 repBind <- which( head_n %in% secondRepSet )
 
-if(length(repAind) == 0 ||
-   length(repBind) == 0) { 
-   print_help(parser)
-   stop("[vast diff error]: Incorrect sampleNames given, one or more do not exist!\n") 
-}
-
-# Indexes of Quals
+## Indexes of Quals
 repA.qualInd <- repAind + 1
 repB.qualInd <- repBind + 1
 
-# make sure this succeeded TODO
-
-# CONST
+## CONST
 alphaList <- seq(0,1,0.01)
 
-### TMP OUT
+## TMP OUT
 if(opt$baseName == "input.DIFF") {
   pdfname <- sub("\\.[^.]*(\\.gz)?$", ".DIFF_plots.pdf", basename(opt$input))
   outname <- sub("\\.[^.]*(\\.gz)?$", ".DIFF.txt", basename(opt$input))
@@ -204,7 +197,7 @@ writeLines(sprintf("GENE\tEVENT\t%s\t%s\tE[dPsi]\tMV[dPsi]_at_%s", opt$sampleNam
 
 
 ### BEGIN READ INPUT ###
-# Iterate through input, 'nLines' at a time to reduce overhead/memory
+## Iterate through input, 'nLines' at a time to reduce overhead/memory
 while(length( lines <- readLines(inputFile, n=opt$nLines) ) > 0) { 
     lines <- strsplit(lines, split="\t")
     ## use parallel computing to store plots in plotListed
@@ -253,7 +246,7 @@ while(length( lines <- readLines(inputFile, n=opt$nLines) ) > 0) {
         plotPrint(plotListed[[it]][[2]], plotListed[[it]][[3]], plotListed[[it]][[1]])
     }
 
-} #End While
+} # End While
 
 if (!opt$noPDF) {garbage <- dev.off()}
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ From release v2.0.0, VAST-TOOLS includes a new module to identify and profile an
 ``vast-tools`` provides two alternative modules (``compare`` and ``diff``) to perform differential splicing analyses on a reduced number of samples per group. Each module gives different functionalities.
 
 - ``compare``: pre-filters the events based on read coverage, imbalance and other features, and simply compares average and individual dPSIs. That is, it looks for non-overlapping PSI distributions based on fixed dPSI cut-offs. For more than 3 replicates, it is likely to be too stringent.
-- ``diff``: performs a statistical test to assess whether the PSI distributions of the two compared groups are signficantly different. It is possible to pre-filter the events based on the minimum number of reads per sample, but subsequent filtering is highly recommended (e.g. overlapping the results with the output of ``tidy``). For more than 5 samples per group it may also be over stringent.
+- ``diff``: performs a statistical test to assess whether the PSI distributions of the two compared groups are signficantly different. It is possible to pre-filter the events based on the minimum number of reads per sample, but subsequent filtering is highly recommended (e.g. overlapping the results with the output of ``tidy``). For more than 5 samples per group it may also be overly stringent.
 - When comparing multiple samples per group, an alternative approach is recommended. First, events should be pre-filtered using ``tidy`` (see [Simplifying Combine Table](#simplifying-combine-table)). This module allows to select events for which a minimum number of samples per group pass the quality controls. Then, a Mann-Whitney U-test or similar can be used to identify differentially spliced events. Finally, average dPSI per group should be calculated and a minimum difference (usually |dPSI| > 15) should be requested.
 
 #### *compare*: Comparing PSIs Between Samples
@@ -446,9 +446,10 @@ Note: Sample names do not have to follow any specific convention as long as they
 Probably the most important extra options to consider are ``-r PROB (--prob)``,
 ``-m MINDIFF (--minDiff)``, ``-e MINREADS (--minReads)``, and `-S MINSAMPLES (--minSamples)`
 These represent the stringency criterion for filtering of visual output and textual
-data sent to file.  `-S` is the minimum number of samples for each set `-a` and `-b`
+output.  `-S` is the minimum number of samples for each set `-a` and `-b`
 that have to have at least `-e` reads each to be considered in the downstream
-statistical comparison.
+statistical comparison. Values in a sample group that do not survive these setting are
+set to NA in the output table and not represented in the PDF.
 
 The ``-r`` flag represents the
 minimal probability of acceptance that is required to consider a comparison to
@@ -458,13 +459,12 @@ stringency requirements.
 The ``-m`` flag represents the minimum value of difference (`MV`, see example below)
 between PSI in group A and PSI in group B that you will accept, such that we are are sure with at least
 probability ``-r`` that there is a difference of at least ``-m``.  `-m` does not
-currently alter the output sent to STDOUT, but does filter what is plotted to PDF
-and printed to file.
+alter the output table, but does filter what is plotted to PDF.
 
 The ``-e`` flag specifies the minimum number of reads for a sample/event to be
 compared.  In cases where the prior distribution has been methodically calculated
 and/or is believable beyond an uninformative prior (like the uniform default),
-this may not be necessary, however it is still highly recommended.  The default
+this may not be necessary, however it is still highly recommended. The default
 value for ``-e`` is 10, though this could easily be higher.
 
 Additionally, ``diff`` allows you to alter the parameters of the conjugate beta
@@ -478,8 +478,8 @@ it may be more appropriate to use a custom prior model that is able to more accu
 reflect the lower expectation of inclusion levels.
 
 In the case that you have paired samples, where NormalA is dependent on
-PerturbationA, it is appropriate to use the ``--paired=TRUE`` flag.  For
-example when considering NormalA and NormalB, to compare to PerturbationA and
+PerturbationA, it is appropriate to use the ``--paired=TRUE`` flag. For
+example, when considering NormalA and NormalB, to compare to PerturbationA and
 PerturbationB, the probability that P( joint_psi1 - joint_psi2 > ``-m`` ) is
 calculated such that NormalA is only compared to PerturbationA, and then NormalB
 is compared to PerturbationB.  No MLE fitting is used in this case.
@@ -495,16 +495,13 @@ posterior distribution to sample, lower numbers decrease accuracy but increase
 performance.
 
 The ``diff`` command is also able to run in parallel. Specify the number of
-cores to use with ``-c INT``
-Obviously more cores will increase the speed of ``diff``, at the cost of increased
-RAM usage.
+cores to use with ``-c INT``. Obviously more cores will increase the speed of ``diff``,
+at the cost of increased memory.
 
 Using the ``-n`` flag to specify the number of lines to read/process at a time,
 will set a max threshold to the RAM used by parallel processing with the ``-c``
 flag.  A lower number means that ``diff`` will use significantly less memory,
-however by decreasing ``-n`` you have increased the number of times that the
-``mclapply`` function must calculate the parallel processing overhead.  The
-default is 100, which works well.
+however, decreasing ``-n`` increases parallelization overhead and extends run time.
 
 *Output Format*
 
@@ -522,7 +519,7 @@ The text output of diff looks like:
  BCORL1	| HsaEX0007940	| 0.213452	| 0.500425	| -0.286973	| 0.05		   
 
 Where for example the first event HsaEX0008312 in the BOD1L gene has multireplicate point estimate
-for SampleA of 0.12 and 0.7 for SampleB.  While this gives an expected value for the difference of
+for SampleA of 0.12 and 0.7 for SampleB. While this gives an expected value for the difference of
 PSI (dPsi/ΔPSI) between SampleA and SampleB of -0.57, the minimum value (`MV`) for |ΔPSI| at 0.95 is
 0.3, meaning that there is a 0.95 probability that |ΔPSI| is greater than 0.3. Use this value
 to filter for events that are statistically likely to have at least a minimal difference of some

--- a/vast-tools
+++ b/vast-tools
@@ -101,7 +101,7 @@ Usage: $0 sub-commands [options]
 
 *** Questions \& Bug Reports: 
     - align, merge, combine, compare, tidy: Manuel Irimia (mirimia\@gmail.com)
-    - diff: Tim Sterne-Weiler (tim.sterne.weiler\@utoronto.ca)
+    - diff: Ulrich Braunschweig (u.braunschweig\@utoronto.ca)
     - plot: Kevin Ha (k.ha\@mail.utoronto.ca)
 
 "


### PR DESCRIPTION
This update contains a number of bug fixes and changes:
- Ensure that shuffled joint beta distributions are compared if replicates are not paired.
- Bug fixes for paired mode
- Tabular output is now filtered according to -e and -S with every event represented but filtered values set to NA
- Improved input checking in diff
- Fixed a warning caused by geom_histogram when specifying bins
- Default for option —size has been changed to 1000
- Removed unnecessary dependency
- Code readability improvements, stability improvements